### PR TITLE
Only use jumbotron on the main page

### DIFF
--- a/_layouts/with-jumbotron.html
+++ b/_layouts/with-jumbotron.html
@@ -2,4 +2,5 @@
 layout: without-jumbotron
 ---
 
+{% include jumbotron.html %}
 {{ content }}

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: with-jumbotron
 permalink: /
 ---
 


### PR DESCRIPTION
This fixes an issue where you click different links from the menu and
the page seemingly doesn't change because the jumbotron takes up your
entire screen.