### PR TITLE
Update ctf.md, fixing permalink

### DIFF
--- a/ctf.md
+++ b/ctf.md
@@ -1,6 +1,6 @@
 ---
 layout: with-jumbotron-ctf
-permalink: /ctf2024
+permalink: /ctf2024/
 ---
 
 


### PR DESCRIPTION
I missed a trailing slash on the permalink path for the CTF 2024 page, wihch doesn't matter or present an issue under `jekyll serve`, but _does_ when serving static assets, at least with the github pages configuration.